### PR TITLE
Pick Frege Compiler from classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
-
+.gradletasknamecache

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ intellij {
 }
 
 dependencies {
-    compile 'org.frege-lang:frege:3.23.370-g898bc8c'
     provided files("${System.properties['java.home']}/../lib/tools.jar")
 }
 sourceSets.main.java.srcDirs = ['src/main/java', 'gen', "$buildDir/generatedSources"]

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 intellij {
-    version 'IC-14.1.4'
+    version '14.1.4'
     pluginName 'Frege'
 
     publish {

--- a/src/main/java/org/fregelang/plugin/idea/run/FregeCommandLineState.java
+++ b/src/main/java/org/fregelang/plugin/idea/run/FregeCommandLineState.java
@@ -59,10 +59,10 @@ public class FregeCommandLineState extends CommandLineState {
      * Cross compile from frege to java
      */
     ProcessHandler fregec = compile(sourcePath, ".fr", "Could not compile with fregec", file -> {
-      PreludeBase.TList args = PreludeBase._toList(new String[]{
+      String[] compilerArgs = {
               "-d", projectOutPath, "-sp", sourcePath, "-nocp", "-greek", "-j", file
-      });
-      return frege.compiler.Main._main(args).apply(args).result().forced();
+      };
+      return frege.compiler.Main.runCompiler(compilerArgs);
     });
     if (fregec != null) return fregec;
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>org.fregelang.plugin.idea</id>
   <name>Frege Plugin</name>
-  <version>0.1.2</version>
+  <version>0.1.3</version>
   <vendor email="rahul.som@gmail.com" url="https://github.com/Frege/frege">The Frege Team</vendor>
 
   <description><![CDATA[
@@ -9,6 +9,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
+      0.1.3 - Frege Compiler is now picked from classpath
       0.1.2 - Run is now much faster because Compiler is reused.
       0.1.1 - Support for Run
       0.1.0 - Initial version


### PR DESCRIPTION
Earlier the plugin was bundling it's own frege jar for compiling, and using the user provided jar for running. This resulted in incompatible builds.

This change makes it possible to compile using the user provided frege jar. So you can run more versions of frege with this plugin.
