### PR TITLE
Support latest IDEA version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 intellij {
-    version '14.1.4'
+    version '15.0.1'
     pluginName 'Frege'
 
     publish {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,15 +9,16 @@
     ]]></description>
 
   <change-notes><![CDATA[
-      0.1.3 - Frege Compiler is now picked from classpath
-      0.1.2 - Run is now much faster because Compiler is reused.
-      0.1.1 - Support for Run
-      0.1.0 - Initial version
+      0.1.4 - Support for more versions of IDEA <br/>
+      0.1.3 - Frege Compiler is now picked from classpath <br/>
+      0.1.2 - Run is now much faster because Compiler is reused. <br/>
+      0.1.1 - Support for Run <br/>
+      0.1.0 - Initial version <br/>
     ]]>
   </change-notes>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="131"/>
+  <idea-version since-build="131" until-build="145"/>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>org.fregelang.plugin.idea</id>
   <name>Frege Plugin</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <vendor email="rahul.som@gmail.com" url="https://github.com/Frege/frege">The Frege Team</vendor>
 
   <description><![CDATA[


### PR DESCRIPTION
I'm not sure how to make the plugin work with a broad range of IDEA versions. However, this will make the plugin work with the latest version of IDEA. May be this will be OK given how JetBrains wants to make updates more often now.
